### PR TITLE
updated facebook universal tile readmes to reflect proper fb messenge…

### DIFF
--- a/universal-tile-templates/facebook-templates/README.md
+++ b/universal-tile-templates/facebook-templates/README.md
@@ -6,9 +6,9 @@ For more information on creating Facebook templates, please see our [developer d
 
 Facebook interactions are limited in capability compared to the full features that are available on other channels, such as web messaging. Some of these limitations include:
 
-* Facebook generic and button templates are limited to displaying to 3 buttons. Additional buttons included in the template will be ignored.
+* Facebook generic and button templates are limited to displaying a maximum of 3 buttons. Including additional buttons will result in an error in displaying the interaction to users.
 * All templates require at least 2 elements in order to render (ex: a single "text" element will fail to appear). Images and buttons built with the Universal Interaction require a title element. If you want to display a single text interaction, use the default Conversation Builder text interaction.
 * "Click" actions are restricted to buttons (in web messaging, click actions can also be added to images). Additionally, multi-action buttons are not compatible with Facebook buttons.
-* In additional to whitelisting image URLs on the LivePerson side, both image and link URLs need to be whitelisted in Facebook's settings. See **[Facebook Messenger setup](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup)** for guidance on authorizing these URLs on Facebook.
+* To display interactions which include button links, all linked URL domains must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
 
 For more information on rich content limitations on Facebook, see our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-limitations.html).

--- a/universal-tile-templates/facebook-templates/fb-button-multiple/README.md
+++ b/universal-tile-templates/facebook-templates/fb-button-multiple/README.md
@@ -2,7 +2,7 @@
 
 This template renders a title and three buttons, each with a "link" action type to direct to a distinct URL. More information on Facebook button templates can be found in our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-button-template.html) and [Facebook's button template reference](https://developers.facebook.com/docs/messenger-platform/reference/templates/button).
 
-> **Note**: To display these buttons, all URL domains must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
+> **Note**: To display this interaction, all URL domains for button links must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
 
 ![fb-button-multiple](fb_Button_Multiple.jpg)
 

--- a/universal-tile-templates/facebook-templates/fb-button-with-url/README.md
+++ b/universal-tile-templates/facebook-templates/fb-button-with-url/README.md
@@ -2,7 +2,7 @@
 
 This template renders a title and button which performs a single "link" action when clicked. Clicking this button will navigate the user to [https://www.liveperson.com](https://www.liveperson.com) in a new tab. More information on Facebook button templates can be found in our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-button-template.html) and [Facebook's button template reference](https://developers.facebook.com/docs/messenger-platform/reference/templates/button).
 
-> **Note**: To display this button, all URL domains must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
+> **Note**: To display this interaction, all URL domains for button links must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
 
 ![fb-button-with-url](fb_Button_With_URL.jpg)
 

--- a/universal-tile-templates/facebook-templates/fb-carousel-template/README.md
+++ b/universal-tile-templates/facebook-templates/fb-carousel-template/README.md
@@ -2,7 +2,7 @@
 
 This template renders a carousel of structured card messages that include a text title, subtitle, image and three buttons that link to distinct web pages. More information on Facebook Carousel Templates can be found in our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-carousel-template.html).
 
-> **Note**: To display this interaction, all URL domains for links and images must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
+> **Note**: To display this interaction, all URL domains for button links must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
 
 ![fb-carousel-template-1](fb_Carousel_Template1.jpg)    ![fb-carousel-template-2](fb_Carousel_Template2.jpg)
 

--- a/universal-tile-templates/facebook-templates/fb-generic-template/README.md
+++ b/universal-tile-templates/facebook-templates/fb-generic-template/README.md
@@ -2,7 +2,7 @@
 
 This template renders a generic structured card message that includes a text title, subtitle, image and three buttons that link to distinct web pages. More information on Facebook Generic Templates can be found in our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-generic-template.html) and [Facebook's generic template reference](https://developers.facebook.com/docs/messenger-platform/reference/templates/generic).
 
-> **Note**: To display this interaction, all URL domains for links and images must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
+> **Note**: To display this interaction, all URL domains for button links must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
 
 ![fb-generic-template](fb_Generic_Template.jpg)
 

--- a/universal-tile-templates/facebook-templates/fb-image-only/README.md
+++ b/universal-tile-templates/facebook-templates/fb-image-only/README.md
@@ -2,8 +2,6 @@
 
 This template renders a generic image interaction which contains an image along with a title. More information on Facebook Generic Templates can be found in our [developer documentation](https://developers.liveperson.com/facebook-messenger-templates-generic-template.html) and [Facebook's generic template reference](https://developers.facebook.com/docs/messenger-platform/reference/templates/generic).
 
-> **Note**: To display this interaction, all URL domains for images must be whitelisted on the Facebook platform. Please see [our documentation](https://developers.liveperson.com/facebook-messenger-templates-introduction.html#facebook-messenger-setup) for guidance on how to whitelist domains in Facebook.
-
 ![fb-image-only](fb_Image_Only.jpg)
 
 ```json


### PR DESCRIPTION
…r behavior

READMEs updated to reflect the following:

- Only button link URLs need to be whitelisted on the Facebook side. Previously, READMEs stated that image domains also needed to be whitelisted on FB. 
- Using more than 3 buttons will result in the interaction failing to display for the user. Previously, our documentation stated that only the excessive buttons would fail to show. 